### PR TITLE
Added more sanitizers

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,8 +15,9 @@ jobs:
     strategy:
       matrix:
         ctect_option:
-          - "-DCHAIVM_ADD_SANITIZERS=OFF"
-          - "-DCHAIVM_ADD_SANITIZERS=ON"
+          - "-DCHAIVM_ADD_MEM_SANITIZER=OFF -DCHAIVM_ADD_THREAD_SANITIZER=OFF"
+          - "-DCHAIVM_ADD_MEM_SANITIZER=OFF -DCHAIVM_ADD_THREAD_SANITIZER=ON"
+          - "-DCHAIVM_ADD_MEM_SANITIZER=ON -DCHAIVM_ADD_THREAD_SANITIZER=OFF"
     steps:
     - uses: actions/checkout@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -26,18 +26,22 @@ build: init
 	cmake -S $(PWD) -B $(PWD)/$(BUILD_DIR) -DCHAIVM_ADD_SANITIZERS=OFF
 	cmake --build $(PWD)/$(BUILD_DIR) --parallel $(JOBS)
 
-.PHONY: build-memcheck
-build-memcheck: init
-	cmake -S $(PWD) -B $(PWD)/$(BUILD_DIR) -DCHAIVM_ADD_SANITIZERS=ON
-	cmake --build $(PWD)/$(BUILD_DIR) --parallel $(JOBS)
-
 .PHONY: test
 test: build
 	export GTEST_COLOR=1 && ctest  --test-dir $(PWD)/$(BUILD_DIR)/test --parallel $(JOBS) --output-on-failure
 
-.PHONY: test-memcheck
-test-memcheck: build-memcheck
+.PHONY: execute-tests-inside-make
+execute-tests-inside-make:
+	cmake --build $(PWD)/$(BUILD_DIR) --parallel $(JOBS)
 	export GTEST_COLOR=1 && ctest --test-dir $(PWD)/$(BUILD_DIR)/test --parallel $(JOBS) --output-on-failure
+
+
+.PHONY: test-extended
+test-extended: init
+	cmake -S $(PWD) -B $(PWD)/$(BUILD_DIR) -DCHAIVM_ADD_MEM_SANITIZER=OFF -DCHAIVM_ADD_THREAD_SANITIZER=ON
+	$(MAKE) execute-tests-inside-make
+	cmake -S $(PWD) -B $(PWD)/$(BUILD_DIR) -DCHAIVM_ADD_MEM_SANITIZER=ON -DCHAIVM_ADD_THREAD_SANITIZER=OFF
+	$(MAKE) execute-tests-inside-make
 
 .PHONY: bench
 bench: init

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,11 +14,15 @@ function(chai_test SOURCE_NAME)
     add_executable(${TARGET_NAME})
     target_sources(${TARGET_NAME} PRIVATE ${SOURCE_NAME})
     target_link_libraries(${TARGET_NAME} PRIVATE chai_testif)
-    if (CHAIVM_ADD_SANITIZERS)
-        # @todo #37:60min Make address sanitizer work on MacOS with ARM
-        target_compile_options(${TARGET_NAME} PRIVATE -fsanitize=address)
-        target_link_options(${TARGET_NAME} PRIVATE -fsanitize=address)
-    endif ()
+    if (CHAIVM_ADD_MEM_SANITIZER AND NOT CHAIVM_ADD_THREAD_SANITIZER)
+        # @todo #37:60min Make address and leak and undefined sanitizer work on MacOS with ARM
+        target_compile_options(${TARGET_NAME} PRIVATE -fsanitize=address -g -fsanitize=leak -fsanitize=undefined)
+        target_link_options(${TARGET_NAME} PRIVATE -fsanitize=address -fsanitize=leak  -fsanitize=undefined)
+    elseif(CHAIVM_ADD_THREAD_SANITIZER AND NOT CHAIVM_ADD_MEM_SANITIZER)
+        # @todo #37:60min Make thread sanitizer work on MacOS with ARM
+        target_compile_options(${TARGET_NAME} PRIVATE -fsanitize=thread -g)
+        target_link_options(${TARGET_NAME} PRIVATE -fsanitize=thread)
+    endif()
     add_test(NAME ${TARGET_NAME} COMMAND ./${TARGET_NAME})
 endfunction(chai_test)
 


### PR DESCRIPTION
Added more sanitizers: `ASAN`, `TSAN`, `LSAN`, `UBSAN.`
Combination of `TSAN` and other sanitizers is not allowed so `TSAN` should be separate check.
See also https://stackoverflow.com/questions/47251533/memory-address-sanitizer-vs-valgrind 